### PR TITLE
[Refactor] sameSite 을 기본값인 Lax로 설정

### DIFF
--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/KakaoAuthController.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/KakaoAuthController.java
@@ -94,14 +94,12 @@ public class KakaoAuthController {
         ResponseCookie accessCookie = ResponseCookie.from("access", token)
                 .httpOnly(true)
                 .path("/")
-                .sameSite("Strict")
                 .maxAge(Duration.ofHours(2))
                 .build();
 
         ResponseCookie kakaoIdCookie = ResponseCookie.from("kakaoId", kakaoId.toString())
                 .httpOnly(true)
                 .path("/")
-                .sameSite("Strict")
                 .maxAge(Duration.ofHours(2))
                 .build();
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #67 

## 📌 작업 내용 및 특이사항
- 쿠키가 발급되는 범위를 지정해줄 수 있는 SameSite 특성의 값을 기존에는 Strict로 줬었는데, 이 경우에는 같은 도메인의 요청에 대해서만 쿠리를 지급한다고 합니다. 이 경우에는 프론트에서 쿠키를 받을 수 없어 계속 401 예외를 받게 됩니다.
- 따라서 기본값인 Lax을 주어서 프론트가 쿠키를 받을 수 있게 구현했습니다.

## 📝 참고사항
-

## 📚 기타
-
