### PR TITLE
[Refactor] Cookie의 sameSite 을 None로 설정

### DIFF
--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/KakaoAuthController.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/KakaoAuthController.java
@@ -94,12 +94,16 @@ public class KakaoAuthController {
         ResponseCookie accessCookie = ResponseCookie.from("access", token)
                 .httpOnly(true)
                 .path("/")
+                .sameSite("None")
+                .secure(true)
                 .maxAge(Duration.ofHours(2))
                 .build();
 
         ResponseCookie kakaoIdCookie = ResponseCookie.from("kakaoId", kakaoId.toString())
                 .httpOnly(true)
                 .path("/")
+                .sameSite("None")
+                .secure(true)
                 .maxAge(Duration.ofHours(2))
                 .build();
 

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/auth/config/WebConfig.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/auth/config/WebConfig.java
@@ -13,7 +13,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins(LOCAL_REACT_CLIENT_URL, REACT_CLIENT_URL)
+                .allowedOriginPatterns(LOCAL_REACT_CLIENT_URL, REACT_CLIENT_URL)
                 .allowedMethods("*")
                 .allowCredentials(true);
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #69 

## 📌 작업 내용 및 특이사항
- sameSite 를 none으로 설정하고 Secure 설정을 true로 했습니다.
- secure = true 로 하게 되면 서버가 https를 사용해야 된다고는 하는데, 정확한 원인을 몰라 일단 설정 해둘 예정입니다.

## 📝 참고사항
-

## 📚 기타
-
