### PR TITLE
[Refactor] CORS 설정과 리다이렉트 주소를 프론트 배포 주소로 변경

### DIFF
--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/KakaoAuthController.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/KakaoAuthController.java
@@ -12,6 +12,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
 import java.time.Duration;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -33,15 +34,12 @@ public class KakaoAuthController {
     private final MemberService memberService;
     private final JwtProvider jwtProvider;
 
-    private static final String MOBILE_BASEURL = "http://172.16.21.135:5173";
-    private static final String LOCAL_BASEURL = "http://localhost:5173";
-    private static final String REFERER = "Referer";
+    private static final String FRONT_BASEURL = "https://morak.vercel.app";
 
     @GetMapping("/auth/login/kakao")
     @KakaoLoginCheckDocs
     public ResponseEntity<Void> checkMemberSignUp(
-            @RequestParam("code") String code,
-            HttpServletRequest request
+            @RequestParam("code") String code
     ) {
         String accessToken = kakaoService.getAccessTokenFromKakao(code);
         KakaoUserInfoResponseDto userInfo = kakaoService.getUserInfo(accessToken);
@@ -49,45 +47,30 @@ public class KakaoAuthController {
 
         KakaoIdStatusDto kakaoIdStatusDto = memberService.initMember(kakaoId);
         String token = jwtProvider.createToken(kakaoIdStatusDto);
-
         List<ResponseCookie> cookies = createCookies(token, kakaoId);
-        String baseUrl = getBaseUrl(request);
-
-        HttpHeaders headers = setHttpHeaders(cookies, kakaoIdStatusDto, baseUrl);
+        HttpHeaders headers = setHttpHeaders(cookies, kakaoIdStatusDto);
         return new ResponseEntity<>(headers, HttpStatus.FOUND);
     }
 
     private static HttpHeaders setHttpHeaders(
-            List<ResponseCookie> cookies, KakaoIdStatusDto kakaoIdStatusDto, String baseUrl
+            List<ResponseCookie> cookies, KakaoIdStatusDto kakaoIdStatusDto
     ) {
         HttpHeaders headers = new HttpHeaders();
         for (ResponseCookie cookie : cookies) {
             headers.add(HttpHeaders.SET_COOKIE, cookie.toString());
         }
         if (kakaoIdStatusDto.getStatus().equals(MemberStatus.MEMBER)) {
-            String redirectUrl = UriComponentsBuilder.fromUriString(baseUrl)
+            String redirectUrl = UriComponentsBuilder.fromUriString(FRONT_BASEURL)
                     .build()
                     .toUriString();
             headers.setLocation(URI.create(redirectUrl));
         } else if (kakaoIdStatusDto.getStatus().equals(MemberStatus.PRE_MEMBER)) {
-            String redirectUrl = UriComponentsBuilder.fromUriString(baseUrl + "/signup")
+            String redirectUrl = UriComponentsBuilder.fromUriString(FRONT_BASEURL + "/signup")
                     .build()
                     .toUriString();
             headers.setLocation(URI.create(redirectUrl));
         }
         return headers;
-    }
-
-    private static String getBaseUrl(HttpServletRequest request) {
-        String referer = request.getHeader(REFERER);
-
-        String baseUrl;
-        if (referer != null && referer.contains("172.16.21.135")) {
-            baseUrl = MOBILE_BASEURL;
-        } else {
-            baseUrl = LOCAL_BASEURL;
-        }
-        return baseUrl;
     }
 
     private static List<ResponseCookie> createCookies(String token, Long kakaoId) {

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/auth/config/WebConfig.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/auth/config/WebConfig.java
@@ -7,13 +7,12 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
     // URL 확인 후에 수정할 수 있음
-    private static final String LOCAL_REACT_CLIENT_URL = "http://localhost:5173";
-    private static final String REACT_CLIENT_URL = "http://172.16.21.135:5173";
+    private static final String REACT_CLIENT_URL = "https://morak.vercel.app";
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOriginPatterns(LOCAL_REACT_CLIENT_URL, REACT_CLIENT_URL)
+                .allowedOrigins(REACT_CLIENT_URL)
                 .allowedMethods("*")
                 .allowCredentials(true);
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #71 

## 📌 작업 내용 및 특이사항
- 현재 쿠키의 설정을 sameSite = None, secure = true 로 사용하고 있는데, 이를 위해서는 반드시 프론트에서 https을 사용해야 합니다.
- 따라서 프론트쪽에서 배포를 진행했고, 기존에 사용하던 주소는 더 이상 사용하지 않습니다.
- 그래서 CORS 관련 설정과 리다이렉트 주소를 배포 주소로 변경하였습니다.

## 📝 참고사항
-

## 📚 기타
-
