### PR TITLE
[Refactor] cookie domain 을 프론트 배포 주소로 설정

### DIFF
--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/KakaoAuthController.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/KakaoAuthController.java
@@ -79,6 +79,7 @@ public class KakaoAuthController {
                 .path("/")
                 .sameSite("None")
                 .secure(true)
+                .domain("morak.vercel.app")
                 .maxAge(Duration.ofHours(2))
                 .build();
 
@@ -87,6 +88,7 @@ public class KakaoAuthController {
                 .path("/")
                 .sameSite("None")
                 .secure(true)
+                .domain("morak.vercel.app")
                 .maxAge(Duration.ofHours(2))
                 .build();
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #73 

## 📌 작업 내용 및 특이사항
- 서버와 프론트의 도메인이 다르기 때문에, cookie 도메인 값을 프론트 배포 주소로 설정해야 합니다.

## 📝 참고사항
-

## 📚 기타
-
