### PR TITLE
[Feat] localhost:5173 CORS 허용

### DIFF
--- a/src/main/java/com/example/seoulpublicdata2025backend/global/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/auth/config/SecurityConfig.java
@@ -32,18 +32,20 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> {
                     auth
-                            .requestMatchers("/reviews/public/**").permitAll()
-                            .requestMatchers("/company/preview").permitAll()
+                            .requestMatchers("/reviews/public/**")
+                                .permitAll()
+                            .requestMatchers("/company/preview")
+                                .permitAll()
                             .requestMatchers("/auth/login/kakao",
                                     "/v3/api-docs/**",
                                     "/swagger-ui/**",
                                     "/swagger-resources/**",
                                     "/webjars/**")
-                            .permitAll()
+                                .permitAll()
                             .requestMatchers(HttpMethod.OPTIONS, "/**")
-                            .permitAll()
+                                .permitAll()
                             .requestMatchers("/member/signup", "/reviews/**")
-                            .hasAuthority("PRE_MEMBER")
+                                .hasAuthority("PRE_MEMBER")
                             .anyRequest()
                             .authenticated();
 
@@ -56,7 +58,10 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOrigins(List.of(
-                "https://morak.site", "https://www.morak.site", "https://api.morak.site"
+                "https://morak.site",
+                "https://www.morak.site",
+                "https://api.morak.site",
+                "http://localhost:5173"
         ));
         config.setAllowedMethods(List.of("GET","POST","PUT","DELETE","OPTIONS"));
         config.setAllowedHeaders(List.of("*"));     // ← 특히 Content-Type, Authorization


### PR DESCRIPTION
## 🌱 관련 이슈
- close #99 

## 📌 작업 내용 및 특이사항
- 프론트 원활한 개발을 위해 localhost:5173 요청을 허용합니다. (CORS 설정)

## 📝 참고사항
-

## 📚 기타
-
