### PR TITLE
[Feat] 회원가입 시 update 된 access token 지급

### DIFF
--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/MemberController.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/MemberController.java
@@ -4,10 +4,13 @@ import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.Signup
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.SignupResponseDto;
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.entity.Member;
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.service.MemberService;
+import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.util.CookieFactory;
+import com.example.seoulpublicdata2025backend.global.auth.jwt.JwtProvider;
 import com.example.seoulpublicdata2025backend.global.swagger.annotations.member.SignUpDocs;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,11 +20,19 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final MemberService memberService;
+    private final JwtProvider jwtProvider;
 
     @PostMapping("/signup")
     @SignUpDocs
-    public ResponseEntity<SignupResponseDto> signup(@Valid @RequestBody SignupRequestDto dto) {
-        SignupResponseDto response = memberService.updateMember(dto);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<Void> signup(@Valid @RequestBody SignupRequestDto dto) {
+        SignupResponseDto signupResponseDto = memberService.updateMember(dto);
+        String updatedToken = jwtProvider.createToken(signupResponseDto.getMemberId(),
+                signupResponseDto.getMemberStatus());
+        // 쿠키 생성
+        ResponseCookie cookie = CookieFactory.createCookie("access", updatedToken);
+
+        return ResponseEntity.ok()
+                .header("Set-Cookie", cookie.toString())
+                .build();
     }
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/dto/SignupResponseDto.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/dto/SignupResponseDto.java
@@ -1,16 +1,19 @@
 package com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto;
 
+import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.type.MemberStatus;
 import lombok.Getter;
 
 @Getter
 public class SignupResponseDto {
     private final Long memberId;
+    private final MemberStatus memberStatus;
 
-    private SignupResponseDto(Long memberId) {
+    private SignupResponseDto(Long memberId, MemberStatus memberStatus) {
         this.memberId = memberId;
+        this.memberStatus = memberStatus;
     }
 
-    public static SignupResponseDto from(Long memberId) {
-        return new SignupResponseDto(memberId);
+    public static SignupResponseDto from(Long memberId, MemberStatus memberStatus) {
+        return new SignupResponseDto(memberId, memberStatus);
     }
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/service/MemberServiceImpl.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/service/MemberServiceImpl.java
@@ -45,7 +45,7 @@ public class MemberServiceImpl implements MemberService {
         Member findMember = memberRepository.findByKakaoId(kakaoId).orElseThrow(
                 () -> new NotFoundMemberException(ErrorCode.MEMBER_NOT_FOUND));
         findMember.update(dto);
-        return SignupResponseDto.from(kakaoId);
+        return SignupResponseDto.from(kakaoId, findMember.getStatus());
     }
 
     @Override

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/util/CookieFactory.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/util/CookieFactory.java
@@ -1,0 +1,18 @@
+package com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.util;
+
+import java.time.Duration;
+import org.springframework.http.ResponseCookie;
+
+public class CookieFactory {
+
+    public static ResponseCookie createCookie(String key, String value) {
+        return ResponseCookie.from(key, value)
+                .httpOnly(true)
+                .path("/")
+                .sameSite("None")
+                .secure(true)
+                .domain(".morak.site")
+                .maxAge(Duration.ofHours(2))
+                .build();
+    }
+}

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/auth/config/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
                             .requestMatchers("/member/signup", "/reviews/**")
                                 .hasAuthority("PRE_MEMBER")
                             .anyRequest()
-                            .authenticated();
+                                .authenticated();
 
                 })
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
@@ -62,7 +62,7 @@ public class SecurityConfig {
                 "https://api.morak.site",
                 "http://localhost:5173"
         ));
-        config.setAllowedMethods(List.of("GET","POST","PUT","DELETE","OPTIONS"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));     // ← 특히 Content-Type, Authorization
         config.setAllowCredentials(true);
         config.setMaxAge(3600L);

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/auth/jwt/JwtProvider.java
@@ -32,10 +32,7 @@ public class JwtProvider {
     }
 
     // JWT 토큰 생성
-    public String createToken(KakaoIdStatusDto dto) {
-        Long kakaoId = dto.getKakaoId();
-        MemberStatus memberStatus = dto.getStatus();
-
+    public String createToken(Long kakaoId, MemberStatus memberStatus) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + accessTokenValidityInMillis);
 

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/exception/ErrorResponse.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/exception/ErrorResponse.java
@@ -36,6 +36,7 @@ public class ErrorResponse {
         this.status = code.getHttpStatus().value();
         this.code = code.getCode();
         this.errors = new ArrayList<>();
+        this.time = LocalDateTime.now();
     }
 
 

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/exception/GlobalExceptionHandler.java
@@ -56,9 +56,19 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
     }
 
+    // 일반적인 RuntimeError 해결
+    @ExceptionHandler(RuntimeException.class)
+    protected ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException e) {
+        log.error("RuntimeException", e);
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(errorResponse);
+    }
+
     // 기타 예외
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
         log.error("Exception", e);
         ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
         return ResponseEntity

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/member/SignUpDocs.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/member/SignUpDocs.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
         @Parameter(name = "name", description = "사용자 이름",example = "홍길동"),
         @Parameter(name = "location", description = "사용자가 사는 동네 주소", example = "서울특별시 강남구"),
         @Parameter(name = "role", description = "소비자라면 CONSUMER, 사장님이면 CORPORATE", example = "CONSUMER"),
-        @Parameter(name = "profileImageUrl", description = "기본 프로필 중에서 어떤 것을 선택했는지 입력하면 될 것 같습니다. 아직 이 부분은 미정입니다.", example = "https://k.kakaocdn.net/dn/example-profile.png")
+        @Parameter(name = "profileColor", description = "기본 프로필의 색깔 표기 (\"gray\", \"pink\", \"blue\", \"orange\") ", example = "pink")
 })
 @RequestBody(
         description = "회원가입 요청 데이터",
@@ -42,7 +42,7 @@ import java.lang.annotation.Target;
                                   "name": "홍길동",
                                   "location": "서울특별시 강남구",
                                   "role": "CONSUMER",
-                                  "profileImageUrl": "https://k.kakaocdn.net/dn/example-profile.png"
+                                  "profileColor": "gray"
                                 }
                                 """
                 )
@@ -50,21 +50,8 @@ import java.lang.annotation.Target;
 )
 @ApiResponse(
         responseCode = "200",
-        description = "회원가입에 성공",
-        content = @Content(
-                mediaType = "application/json",
-                schema = @Schema(implementation = SignupResponseDto.class),
-                examples = @ExampleObject(
-                                name = "회원가입 성공 예시",
-                                description = "성공한 회원가입 응답 예시",
-                                value = """
-                                {
-                                    "memberId": 1
-                                }
-                                """
-                        )
-
-        )
+        description = "회원가입에 성공. 본문 없이 Set-Cookie 헤더에 accessToken을 포함합니다.",
+        content = @Content(schema = @Schema(hidden = true))
 )
 @ApiResponse(
         responseCode = "400",
@@ -115,6 +102,26 @@ import java.lang.annotation.Target;
         )
 )
 @ApiResponse(
+        responseCode = "404",
+        description = "존재하지 않는 kakaoId",
+        content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                        name = "회원가입 실패 - 존재하지 않는 kakaoId",
+                        description = "존재하지 않는 카카오 ID로 가입을 시도했을 때",
+                        value = """
+                                {
+                                  "status": 404,
+                                  "code": "MEMBER_NOT_FOUND",
+                                  "message": "사용자를 찾을 수 없습니다.",
+                                  "errors": [],
+                                  "time": "2025-04-15T10:12:34"
+                                }
+                                """
+                )
+        )
+)
+@ApiResponse(
         responseCode = "409",
         description = "이미 가입된 회원",
         content = @Content(
@@ -124,9 +131,9 @@ import java.lang.annotation.Target;
                         description = "이미 존재하는 카카오 ID로 가입을 시도했을 때",
                         value = """
                                 {
-                                  "status": 404,
-                                  "code": "MEMBER_NOT_FOUND",
-                                  "message": "사용자를 찾을 수 없습니다.",
+                                  "status": 409,
+                                  "code": "DUPLICATE_MEMBER",
+                                  "message": "이미 가입된 사용자입니다.",
                                   "errors": [],
                                   "time": "2025-04-15T10:12:34"
                                 }

--- a/src/test/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/MemberControllerTests.java
+++ b/src/test/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/controller/MemberControllerTests.java
@@ -1,0 +1,116 @@
+package com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.controller;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.SignupRequestDto;
+import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dto.SignupResponseDto;
+import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.service.MemberService;
+import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.type.MemberStatus;
+import com.example.seoulpublicdata2025backend.global.auth.jwt.JwtProvider;
+import com.example.seoulpublicdata2025backend.global.exception.GlobalExceptionHandler;
+import com.example.seoulpublicdata2025backend.global.exception.customException.DuplicationMemberException;
+import com.example.seoulpublicdata2025backend.global.exception.errorCode.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class MemberControllerTests {
+    @Mock
+    MemberService memberService;
+
+    @Mock
+    JwtProvider jwtProvider;
+
+    @InjectMocks
+    MemberController memberController;
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        mockMvc = MockMvcBuilders.standaloneSetup(memberController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    @DisplayName("회원가입 성공")
+    void signUp_success() throws Exception {
+        SignupRequestDto request = new SignupRequestDto("name","location","CONSUMER","gray");
+        SignupResponseDto response = SignupResponseDto.from(-1L, MemberStatus.PRE_MEMBER);
+
+        when(memberService.updateMember(any(SignupRequestDto.class))).thenReturn(response);
+        when(jwtProvider.createToken(response.getMemberId(), response.getMemberStatus())).thenReturn("valid-token");
+
+        mockMvc.perform(post("/member/signup")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding(StandardCharsets.UTF_8)
+                .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("access=valid-token")))
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("Secure")))
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("SameSite=None")));
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 이미 존재하는 유저")
+    void signUp_fail_duplicate() throws Exception {
+
+        SignupRequestDto request = new SignupRequestDto("name","location","CONSUMER","gray");
+
+        when(memberService.updateMember(any(SignupRequestDto.class)))
+                .thenThrow(new DuplicationMemberException(ErrorCode.DUPLICATE_MEMBER));
+
+        mockMvc.perform(post("/member/signup")
+                .contentType("application/json")
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("이미 가입된 사용자입니다."))
+                .andExpect(jsonPath("$.status").value(409))
+                .andExpect(jsonPath("$.code").value("3000"))
+                .andExpect(jsonPath("$.errors").isArray())
+                .andExpect(jsonPath("$.errors").isEmpty())
+                .andExpect(jsonPath("$.time").exists());
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 요청 값 중 null 있음")
+    void signUp_fail_parameter_null() throws Exception {
+
+        SignupRequestDto request = new SignupRequestDto(null,"location","CONSUMER","gray");
+
+        mockMvc.perform(post("/member/signup")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("입력값이 올바르지 않습니다.")) // 에러 메시지 정의에 따라 수정
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.code").value("2000"))
+                .andExpect(jsonPath("$.errors").isArray())
+                .andExpect(jsonPath("$.errors[0].field").value("name"));
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #112 

## 📌 작업 내용 및 특이사항
- 기존에 PRE_MEMBER 였던 권한을 MEMBER로 수정하고, 수정된 권한을 담은 access token 을 전달해줍니다.
- 이 과정으로 기존에 회원가입을 한 유저는 카카오 로그인 버튼을 눌렀을 때 지도 화면으로 리다이렉트 됩니다.
- Cookie 를 생성하는 CookieFactory 를 만들어 로직을 분리하였습니다.
- 로직이 변경됨에 따라 swagger도 변경하였습니다.
```java
@PostMapping("/signup")
    @SignUpDocs
    public ResponseEntity<Void> signup(@Valid @RequestBody SignupRequestDto dto) {
        SignupResponseDto signupResponseDto = memberService.updateMember(dto);
        String updatedToken = jwtProvider.createToken(signupResponseDto.getMemberId(),
                signupResponseDto.getMemberStatus());
        // 쿠키 생성
        ResponseCookie cookie = CookieFactory.createCookie("access", updatedToken);

        return ResponseEntity.ok()
                .header("Set-Cookie", cookie.toString())
                .build();
    }
```

## 📝 참고사항
-

## 📚 기타
-
