### PR TITLE
[Feat] reviewDto 수정

### DIFF
--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/review/dto/CompanyReviewDto.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/review/dto/CompanyReviewDto.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 
 @Getter
 @AllArgsConstructor
@@ -25,5 +26,5 @@ public class CompanyReviewDto {
     @NotNull(message = "온도를 체크해주세요.")
     private Double temperature;
 
-    private ReviewCategory reviewCategory;
+    private Set<ReviewCategory> reviewCategories;
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/review/entity/CompanyReview.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/review/entity/CompanyReview.java
@@ -10,6 +10,8 @@ import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Table(name = "company_reviews")
@@ -44,13 +46,22 @@ public class CompanyReview {
     private String review;
     private Double temperature;
 
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(
+            name = "company_review_category",
+            joinColumns = {
+                    @JoinColumn(name = "paymentInfo_confirm_num", referencedColumnName = "paymentInfo_confirm_num"),
+                    @JoinColumn(name = "paymentInfo_time", referencedColumnName = "paymentInfo_time")
+            }
+    )
     @Enumerated(EnumType.STRING)
     @Column(name = "review_category")
-    private ReviewCategory reviewCategory;
+    private Set<ReviewCategory> reviewCategories = new HashSet<>();
 
-    public void updateReview(String review, Double temperature, ReviewCategory reviewCategory) {
+
+    public void updateReview(String review, Double temperature, Set<ReviewCategory> reviewCategories) {
         this.review = review;
         this.temperature = temperature;
-        this.reviewCategory = reviewCategory;
+        this.reviewCategories = reviewCategories;
     }
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/review/service/ReviewServiceImpl.java
@@ -36,7 +36,7 @@ public class ReviewServiceImpl implements ReviewService {
                 .kakao(Member.builder().kakaoId(currentKakaoId).build())
                 .review(dto.getReview())
                 .temperature(dto.getTemperature())
-                .reviewCategory(dto.getReviewCategory())
+                .reviewCategories(dto.getReviewCategories())
                 .build();
 
         CompanyReview saved = companyReviewRepository.save(entity);
@@ -48,7 +48,7 @@ public class ReviewServiceImpl implements ReviewService {
                 saved.getKakao(),
                 saved.getReview(),
                 saved.getTemperature(),
-                saved.getReviewCategory()
+                saved.getReviewCategories()
         );    }
 
     @Override
@@ -58,7 +58,7 @@ public class ReviewServiceImpl implements ReviewService {
         ).orElseThrow(() -> new IllegalArgumentException("리뷰가 존재하지 않습니다."));
 
         // 필드 업데이트
-        entity.updateReview(dto.getReview(), dto.getTemperature(), dto.getReviewCategory());
+        entity.updateReview(dto.getReview(), dto.getTemperature(), dto.getReviewCategories());
 
         CompanyReview updated = companyReviewRepository.save(entity);
 
@@ -69,7 +69,7 @@ public class ReviewServiceImpl implements ReviewService {
                 updated.getKakao(),
                 updated.getReview(),
                 updated.getTemperature(),
-                updated.getReviewCategory()
+                updated.getReviewCategories()
         );
     }
 
@@ -89,7 +89,7 @@ public class ReviewServiceImpl implements ReviewService {
                 entity.getKakao(),
                 entity.getReview(),
                 entity.getTemperature(),
-                entity.getReviewCategory()
+                entity.getReviewCategories()
         );
     }
 

--- a/src/test/java/com/example/seoulpublicdata2025backend/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/example/seoulpublicdata2025backend/domain/review/controller/ReviewControllerTest.java
@@ -25,6 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -84,7 +85,7 @@ class ReviewControllerTest {
                 Member.builder().kakaoId(1001L).name("홍길동").build(),
                 "친절하고 깨끗했어요!",
                 89.5,
-                ReviewCategory.CLEAN
+                Set.of(ReviewCategory.CLEAN)
         );
 
         when(MockConfig.reviewService.creatCompanyReview(any())).thenReturn(requestDto);

--- a/src/test/java/com/example/seoulpublicdata2025backend/domain/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/example/seoulpublicdata2025backend/domain/review/service/ReviewServiceImplTest.java
@@ -22,7 +22,9 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -113,7 +115,7 @@ class ReviewServiceImplTest {
                 .kakao(member)
                 .review("좋아요1!")
                 .temperature(85.5)
-                .reviewCategory(ReviewCategory.CLEAN)
+                .reviewCategories(Set.of(ReviewCategory.CLEAN, ReviewCategory.GOOD_QUALITY))
                 .build();
         entityManager.persist(review1);
 
@@ -125,7 +127,7 @@ class ReviewServiceImplTest {
                 .kakao(member)
                 .review("좋아요2!")
                 .temperature(88.5)
-                .reviewCategory(ReviewCategory.CLEAN)
+                .reviewCategories(Set.of(ReviewCategory.CLEAN, ReviewCategory.GOOD_QUALITY))
                 .build();
         entityManager.persist(review2);
 
@@ -137,7 +139,7 @@ class ReviewServiceImplTest {
                 .kakao(member2)
                 .review("좋아요3!")
                 .temperature(88.5)
-                .reviewCategory(ReviewCategory.CLEAN)
+                .reviewCategories(Set.of(ReviewCategory.CLEAN, ReviewCategory.GOOD_QUALITY))
                 .build();
         entityManager.persist(review3);
 
@@ -195,7 +197,7 @@ class ReviewServiceImplTest {
                 .kakao(entityManager.find(Member.class, testKakaoId1))
                 .review("방금 작성한 리뷰")
                 .temperature(95.0)
-                .reviewCategory(ReviewCategory.CLEAN)
+                .reviewCategories(Set.of(ReviewCategory.CLEAN))
                 .build();
 
         companyReviewRepository.save(review);
@@ -215,13 +217,13 @@ class ReviewServiceImplTest {
         CompanyReviewId id = new CompanyReviewId(1L, companyReviewRepository.findById(new CompanyReviewId(1L, reviewTime1)).get().getPaymentInfoTime());
         CompanyReview review = companyReviewRepository.findById(id).orElseThrow();
 
-        review.updateReview("수정된 리뷰", 77.7, ReviewCategory.CLEAN);
+        review.updateReview("수정된 리뷰", 77.7, new HashSet<>(Set.of(ReviewCategory.CLEAN)));
         companyReviewRepository.save(review);
 
         CompanyReview updated = companyReviewRepository.findById(id).orElseThrow();
         assertEquals("수정된 리뷰", updated.getReview());
         assertEquals(77.7, updated.getTemperature());
-        assertEquals(ReviewCategory.CLEAN, updated.getReviewCategory());
+        assertTrue(updated.getReviewCategories().contains(ReviewCategory.CLEAN));
     }
 
     @Test


### PR DESCRIPTION
## 🌱 관련 이슈
- close #118 

## 📌 작업 내용 및 특이사항
- CompanyReview Entity에서 다음을 수정하였습니다.
```java
    @ElementCollection(fetch = FetchType.LAZY)
    @CollectionTable(
            name = "company_review_category",
            joinColumns = {
                    @JoinColumn(name = "paymentInfo_confirm_num", referencedColumnName = "paymentInfo_confirm_num"),
                    @JoinColumn(name = "paymentInfo_time", referencedColumnName = "paymentInfo_time")
            }
    )
    @Enumerated(EnumType.STRING)
    @Column(name = "review_category")
    private Set<ReviewCategory> reviewCategories = new HashSet<>();
```
- 이는 사용자가 카테고리를 여러개 선택할 수 있게 하기 위함입니다.
- reviewDto에 Set<reviewCategory> 를 추가하였습니다.
- 이후 MySQL의 company_review테이블을 수정하고 더미데이터를 수정하였습니다.
- MySQL에 company_review_categories 라는 테이블을 만들고 더미데이터를 추가하였습니다.

## 📝 참고사항
-

## 📚 기타
-
