### PR TITLE
[Fix] 이미 가입한 멤버라면 초기화를 하지 않게 수정

### DIFF
--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/service/MemberServiceImpl.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/kakaoSocialLogin/service/MemberServiceImpl.java
@@ -29,13 +29,14 @@ public class MemberServiceImpl implements MemberService {
     @Override
     @Transactional
     public KakaoIdStatusDto initMember(Long kakaoId) {
-        Member member = Member.init(kakaoId);
-        try {
-            memberRepository.save(member);
-            return new KakaoIdStatusDto(member.getKakaoId(), member.getStatus());
-        } catch (DataIntegrityViolationException exception) {
-            throw new DuplicationMemberException(ErrorCode.DUPLICATE_MEMBER);
-        }
+        // member 를 찾고 이미 가입된 member 라면 init을 하지 않는다.
+        Member member = memberRepository.findByKakaoId(kakaoId)
+                .orElseGet(() -> {
+                    Member newMember = Member.init(kakaoId);
+                    return memberRepository.save(newMember);
+                });
+
+        return new KakaoIdStatusDto(member.getKakaoId(), member.getStatus());
     }
 
     @Override


### PR DESCRIPTION
## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- 이미 가입한 멤버도 정보를 초기화해버리는 문제가 있었는데, 이를 해결하였습니다.

## 📝 참고사항
-

## 📚 기타
-
