### PR TITLE
[Fix] 커스텀 예외를 만들어 예외를 catch 할 수 있게 수정

### DIFF
--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/company/service/CompanyServiceImpl.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/company/service/CompanyServiceImpl.java
@@ -6,6 +6,8 @@ import com.example.seoulpublicdata2025backend.domain.company.dto.CompanyPreviewD
 import com.example.seoulpublicdata2025backend.domain.company.entity.Company;
 import com.example.seoulpublicdata2025backend.domain.review.dao.CompanyReviewRepository;
 import com.example.seoulpublicdata2025backend.domain.review.service.ReviewService;
+import com.example.seoulpublicdata2025backend.global.exception.customException.NotFoundCompanyException;
+import com.example.seoulpublicdata2025backend.global.exception.errorCode.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -27,7 +29,7 @@ public class CompanyServiceImpl implements CompanyService {
     @Override
     public CompanyPreviewDto companyPreview(Long companyId) {
         Company company = companyRepository.findByCompanyId(companyId)
-                .orElseThrow(() -> new IllegalArgumentException("Not Exist CompanyId: " + companyId));
+                .orElseThrow(() -> new NotFoundCompanyException(ErrorCode.COMPANY_NOT_FOUND));
 
         Double temperatureAvg = reviewService.getTemperature(companyId);
         Long reviewCount = reviewService.getCountCompanyReview(companyId);

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/company/service/GeocodingServiceImpl.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/company/service/GeocodingServiceImpl.java
@@ -3,6 +3,8 @@ package com.example.seoulpublicdata2025backend.domain.company.service;
 import com.example.seoulpublicdata2025backend.domain.company.dao.CompanyRepository;
 import com.example.seoulpublicdata2025backend.domain.company.dto.MemberLocationDto;
 import com.example.seoulpublicdata2025backend.domain.company.entity.Company;
+import com.example.seoulpublicdata2025backend.global.exception.customException.NotFoundCompanyException;
+import com.example.seoulpublicdata2025backend.global.exception.errorCode.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.springframework.stereotype.Service;
@@ -24,7 +26,7 @@ public class GeocodingServiceImpl implements GeocodingService{
     public String getNmapSchemeUrl(MemberLocationDto memberLocationDto, Long companyId) {
 
         Company company = companyRepository.findByCompanyId(companyId)
-                .orElseThrow(() -> new IllegalArgumentException("Not Exist CompanyId: " + companyId));
+                .orElseThrow(() -> new NotFoundCompanyException(ErrorCode.COMPANY_NOT_FOUND));
 
         double dlat = company.getLocation().getLatitude();
         double dlng = company.getLocation().getLongitude();

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/company/service/MemberCompanySaveServiceImpl.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/company/service/MemberCompanySaveServiceImpl.java
@@ -8,6 +8,10 @@ import com.example.seoulpublicdata2025backend.domain.company.entity.MemberCompan
 import com.example.seoulpublicdata2025backend.domain.company.entity.MemberCompanySaveId;
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.dao.MemberRepository;
 import com.example.seoulpublicdata2025backend.domain.kakaoSocialLogin.entity.Member;
+import com.example.seoulpublicdata2025backend.global.exception.customException.MemberCompanySaveException;
+import com.example.seoulpublicdata2025backend.global.exception.customException.NotFoundCompanyException;
+import com.example.seoulpublicdata2025backend.global.exception.customException.NotFoundMemberException;
+import com.example.seoulpublicdata2025backend.global.exception.errorCode.ErrorCode;
 import com.example.seoulpublicdata2025backend.global.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,13 +33,13 @@ public class MemberCompanySaveServiceImpl implements MemberCompanySaveService {
         Long currentKakaoId = SecurityUtil.getCurrentMemberKakaoId();
 
         if (memberCompanySaveRepository.existsByKakaoIdAndCompanyId(currentKakaoId, companyId)) {
-            throw new IllegalStateException("이미 찜한 기업입니다.");
+            throw new MemberCompanySaveException(ErrorCode.DUPLICATE_COMPANY_SAVE);
         }
 
         Member member = memberRepository.findByKakaoId(currentKakaoId)
-                .orElseThrow(() -> new RuntimeException("회원이 존재하지 않습니다."));
+                .orElseThrow(() -> new NotFoundMemberException(ErrorCode.MEMBER_NOT_FOUND));
         Company company = companyRepository.findById(companyId)
-                .orElseThrow(() -> new RuntimeException("기업이 존재하지 않습니다."));
+                .orElseThrow(() -> new NotFoundCompanyException(ErrorCode.COMPANY_NOT_FOUND));
 
         MemberCompanySave like = MemberCompanySave.builder()
                 .kakaoId(currentKakaoId)
@@ -55,7 +59,7 @@ public class MemberCompanySaveServiceImpl implements MemberCompanySaveService {
         MemberCompanySaveId id = new MemberCompanySaveId(currentKakaoId, companyId);
 
         MemberCompanySave save = memberCompanySaveRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("찜한 기록이 없습니다."));
+                .orElseThrow(() -> new MemberCompanySaveException(ErrorCode.COMPANY_SAVE_RECORD_NOT_FOUND));
 
         memberCompanySaveRepository.delete(save);
     }

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/exception/customException/MemberCompanySaveException.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/exception/customException/MemberCompanySaveException.java
@@ -1,0 +1,9 @@
+package com.example.seoulpublicdata2025backend.global.exception.customException;
+
+import com.example.seoulpublicdata2025backend.global.exception.errorCode.ErrorCode;
+
+public class MemberCompanySaveException extends CustomException {
+    public MemberCompanySaveException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/exception/errorCode/ErrorCode.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/exception/errorCode/ErrorCode.java
@@ -11,7 +11,7 @@ public enum ErrorCode {
     // 1000번대: 인증 관련
     INVALID_CODE("1000", "유효하지 않은 인가코드입니다.", HttpStatus.BAD_REQUEST),
     UNAUTHORIZED("1001", "인증되지 않은 요청입니다.", HttpStatus.UNAUTHORIZED),
-    INVALID_TOKEN("1002","유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_TOKEN("1002", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
     INVALID_KAKAO_REQUEST("1098", "카카오 인가 요청이 잘못되었습니다.", HttpStatus.BAD_REQUEST),
     KAKAO_SERVER_ERROR("1099", "카카오 서버에 문제가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
@@ -28,7 +28,9 @@ public enum ErrorCode {
     FORBIDDEN("4000", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
 
     // 5000번대: 기업 관련 리뷰
-    COMPANY_NOT_FOUND("5000","기업을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    COMPANY_NOT_FOUND("5000", "기업을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    DUPLICATE_COMPANY_SAVE("5001", "이미 찜한 기업입니다.", HttpStatus.CONFLICT),
+    COMPANY_SAVE_RECORD_NOT_FOUND("5002", "찜한 기록이 없습니다.", HttpStatus.NOT_FOUND),
 
     // 9000번대: 서버 오류
     INTERNAL_SERVER_ERROR("9000", "서버에 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
@@ -47,7 +49,8 @@ public enum ErrorCode {
 
     // 7000번대 : Naver Ocr 요청 중 예외
     NAVER_OCR_BAD_REQUEST("7000", "NAVER OCR 요청이 잘못되었습니다. (400 Bad Request)", HttpStatus.BAD_REQUEST),
-    NAVER_OCR_INTERNAL_SERVER_ERROR("7001", "NAVER OCR 서버 오류가 발생했습니다. (500 Internal Server Error)", HttpStatus.INTERNAL_SERVER_ERROR),
+    NAVER_OCR_INTERNAL_SERVER_ERROR("7001", "NAVER OCR 서버 오류가 발생했습니다. (500 Internal Server Error)",
+            HttpStatus.INTERNAL_SERVER_ERROR),
     ;
 
     private final String code;

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/company/SaveCompanyDocs.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/company/SaveCompanyDocs.java
@@ -18,7 +18,9 @@ import java.lang.annotation.*;
         @Parameter(name = "companyId", description = "찜할 대상 기업의 ID", example = "1")
 })
 @ApiResponse(responseCode = "200", description = "찜 등록 성공")
-@ApiResponse(responseCode = "400", description = "이미 찜한 기업인 경우")
+@ApiResponse(responseCode = "409", description = "이미 찜한 기업인 경우")
 @ApiResponse(responseCode = "404", description = "존재하지 않는 회원 또는 기업")
 public @interface SaveCompanyDocs {
 }
+
+


### PR DESCRIPTION
## 🌱 관련 이슈
- close #121 

## 📌 작업 내용 및 특이사항
- 기존에 IllegalStateException 예외를 처리하는 핸들러가 없어 500 에러를 반환하는 문제가 있었습니다. 따라서 IllegalStateException 대신에 CustomException 을 상속받는 새로운 예외를 만들어 클라이언트가 유의미한 예외 메시지를 받을 수 있도록 수정하였습니다.
- 아래는 수정한 코드입니다.
```java
 @Transactional
    @Override
    public void saveCompany(Long companyId) {
        Long currentKakaoId = SecurityUtil.getCurrentMemberKakaoId();

        if (memberCompanySaveRepository.existsByKakaoIdAndCompanyId(currentKakaoId, companyId)) {
            throw new MemberCompanySaveException(ErrorCode.DUPLICATE_COMPANY_SAVE);
        }

        Member member = memberRepository.findByKakaoId(currentKakaoId)
                .orElseThrow(() -> new NotFoundMemberException(ErrorCode.MEMBER_NOT_FOUND));
        Company company = companyRepository.findById(companyId)
                .orElseThrow(() -> new NotFoundCompanyException(ErrorCode.COMPANY_NOT_FOUND));

        MemberCompanySave like = MemberCompanySave.builder()
                .kakaoId(currentKakaoId)
                .companyId(companyId)
                .member(member)
                .company(company)
                .build();

        memberCompanySaveRepository.save(like);
    }
```

## 📝 참고사항
-

## 📚 기타
-
