### PR TITLE
Feat/150 consumption return add name count

### DIFF
--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/member/controller/MemberConsumptionController.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/member/controller/MemberConsumptionController.java
@@ -1,0 +1,57 @@
+package com.example.seoulpublicdata2025backend.domain.member.controller;
+
+import com.example.seoulpublicdata2025backend.domain.company.entity.CompanyType;
+import com.example.seoulpublicdata2025backend.domain.member.dto.MemberConsumptionDetailResponseDto;
+import com.example.seoulpublicdata2025backend.domain.member.dto.MemberConsumptionDto;
+import com.example.seoulpublicdata2025backend.domain.member.dto.MemberConsumptionResponseDto;
+import com.example.seoulpublicdata2025backend.domain.member.service.MemberConsumptionService;
+import com.example.seoulpublicdata2025backend.domain.member.service.MemberService;
+import com.example.seoulpublicdata2025backend.domain.review.service.ReviewService;
+import com.example.seoulpublicdata2025backend.global.swagger.annotations.member.GetMeberConsumptionDetailDocs;
+import com.example.seoulpublicdata2025backend.global.swagger.annotations.member.GetMemberConsumptionDocs;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member/consumption")
+public class MemberConsumptionController {
+
+    private final MemberService memberService;
+    private final MemberConsumptionService memberConsumptionService;
+    private final ReviewService reviewService;
+
+    @GetMapping
+    @GetMemberConsumptionDocs
+    public ResponseEntity<MemberConsumptionResponseDto> getMemberConsumption() {
+        List<MemberConsumptionDto> consumptions = memberConsumptionService.findConsumptionByMember();
+        String memberName = memberService.findMemberName();
+        Long reviewCount = reviewService.getCountMemberReview();
+        MemberConsumptionResponseDto response = MemberConsumptionResponseDto.builder()
+                .consumptions(consumptions)
+                .name(memberName)
+                .reviewCount(reviewCount)
+                .build();
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/detail")
+    @GetMeberConsumptionDetailDocs
+    public ResponseEntity<MemberConsumptionDetailResponseDto> getMemberConsumptionDetail(@RequestParam CompanyType companyType) {
+        MemberConsumptionDto consumption = memberConsumptionService.findConsumptionByMemberAndCompanyType(
+                companyType);
+        String memberName = memberService.findMemberName();
+        Long reviewCount = reviewService.getCountMemberReview();
+        MemberConsumptionDetailResponseDto response = MemberConsumptionDetailResponseDto.builder()
+                .consumption(consumption)
+                .name(memberName)
+                .reviewCount(reviewCount)
+                .build();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/member/controller/MemberController.java
@@ -2,18 +2,20 @@ package com.example.seoulpublicdata2025backend.domain.member.controller;
 
 import com.example.seoulpublicdata2025backend.domain.company.entity.CompanyType;
 import com.example.seoulpublicdata2025backend.domain.member.dto.AuthResponseDto;
-import com.example.seoulpublicdata2025backend.domain.member.util.CookieFactory;
 import com.example.seoulpublicdata2025backend.domain.member.dto.MemberConsumptionResponseDto;
+import com.example.seoulpublicdata2025backend.domain.member.util.CookieFactory;
+import com.example.seoulpublicdata2025backend.domain.member.dto.MemberConsumptionDto;
 import com.example.seoulpublicdata2025backend.domain.member.dto.SignupRequestDto;
 import com.example.seoulpublicdata2025backend.domain.member.dto.SignupResponseDto;
 import com.example.seoulpublicdata2025backend.domain.member.service.MemberConsumptionService;
 import com.example.seoulpublicdata2025backend.domain.member.service.MemberService;
+import com.example.seoulpublicdata2025backend.domain.review.entity.CompanyReview;
+import com.example.seoulpublicdata2025backend.domain.review.service.ReviewService;
 import com.example.seoulpublicdata2025backend.global.auth.jwt.JwtProvider;
 import com.example.seoulpublicdata2025backend.global.swagger.annotations.member.GetMeberConsumptionDetailDocs;
 import com.example.seoulpublicdata2025backend.global.swagger.annotations.member.GetMemberConsumptionDocs;
 import com.example.seoulpublicdata2025backend.global.swagger.annotations.member.LogoutDocs;
 import com.example.seoulpublicdata2025backend.global.swagger.annotations.member.SignUpDocs;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +31,6 @@ public class MemberController {
 
     private final MemberService memberService;
     private final JwtProvider jwtProvider;
-    private final MemberConsumptionService memberConsumptionService;
 
     @PostMapping("/signup")
     @SignUpDocs
@@ -43,20 +44,6 @@ public class MemberController {
         return ResponseEntity.ok()
                 .header("Set-Cookie", cookie.toString())
                 .build();
-    }
-
-    @GetMapping("/consumption")
-    @GetMemberConsumptionDocs
-    public ResponseEntity<List<MemberConsumptionResponseDto>> getMemberConsumption() {
-        List<MemberConsumptionResponseDto> response = memberConsumptionService.findConsumptionByMember();
-        return ResponseEntity.ok(response);
-    }
-
-    @GetMapping("/consumption/detail")
-    @GetMeberConsumptionDetailDocs
-    public ResponseEntity<MemberConsumptionResponseDto> getMemberConsumptionDetail(@RequestParam CompanyType companyType) {
-        MemberConsumptionResponseDto response = memberConsumptionService.findConsumptionByMemberAndCompanyType(companyType);
-        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/logout")

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/member/dao/MemberRepository.java
@@ -15,4 +15,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("SELECT new com.example.seoulpublicdata2025backend.domain.member.dto.AuthResponseDto(m.name, m.profileColor) " +
             "FROM Member m WHERE m.kakaoId = :kakaoId")
     Optional<AuthResponseDto> findAuthResponseByKakaoId(Long kakaoId);
+
+    @Query("SELECT m.name FROM Member m WHERE m.kakaoId = :kakaoId")
+    Optional<String> findMemberName(Long kakaoId);
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/member/dto/MemberConsumptionDetailResponseDto.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/member/dto/MemberConsumptionDetailResponseDto.java
@@ -1,13 +1,12 @@
 package com.example.seoulpublicdata2025backend.domain.member.dto;
 
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
-public class MemberConsumptionResponseDto {
+public class MemberConsumptionDetailResponseDto {
+    private MemberConsumptionDto consumption;
     private String name;
     private Long reviewCount;
-    private List<MemberConsumptionDto> consumptions;
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/member/dto/MemberConsumptionDto.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/member/dto/MemberConsumptionDto.java
@@ -1,0 +1,12 @@
+package com.example.seoulpublicdata2025backend.domain.member.dto;
+
+import com.example.seoulpublicdata2025backend.domain.company.entity.CompanyType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberConsumptionDto {
+    private CompanyType companyType;
+    private Long totalPrice;
+}

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/member/service/MemberConsumptionService.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/member/service/MemberConsumptionService.java
@@ -2,13 +2,13 @@ package com.example.seoulpublicdata2025backend.domain.member.service;
 
 import com.example.seoulpublicdata2025backend.domain.company.dto.CompanyLocationTypeDto;
 import com.example.seoulpublicdata2025backend.domain.company.entity.CompanyType;
-import com.example.seoulpublicdata2025backend.domain.member.dto.MemberConsumptionResponseDto;
+import com.example.seoulpublicdata2025backend.domain.member.dto.MemberConsumptionDto;
 import java.util.List;
 
 public interface MemberConsumptionService {
     void saveConsumption(CompanyLocationTypeDto companyDto, Long totalPrice);
 
-    List<MemberConsumptionResponseDto> findConsumptionByMember();
+    List<MemberConsumptionDto> findConsumptionByMember();
 
-    MemberConsumptionResponseDto findConsumptionByMemberAndCompanyType(CompanyType companyType);
+    MemberConsumptionDto findConsumptionByMemberAndCompanyType(CompanyType companyType);
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/member/service/MemberConsumptionServiceImpl.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/member/service/MemberConsumptionServiceImpl.java
@@ -3,7 +3,7 @@ package com.example.seoulpublicdata2025backend.domain.member.service;
 import com.example.seoulpublicdata2025backend.domain.company.dto.CompanyLocationTypeDto;
 import com.example.seoulpublicdata2025backend.domain.company.entity.CompanyType;
 import com.example.seoulpublicdata2025backend.domain.member.dao.MemberRepository;
-import com.example.seoulpublicdata2025backend.domain.member.dto.MemberConsumptionResponseDto;
+import com.example.seoulpublicdata2025backend.domain.member.dto.MemberConsumptionDto;
 import com.example.seoulpublicdata2025backend.domain.member.entity.Member;
 import com.example.seoulpublicdata2025backend.domain.member.dao.MemberConsumptionRepository;
 import com.example.seoulpublicdata2025backend.domain.member.entity.MemberConsumption;
@@ -44,13 +44,13 @@ public class MemberConsumptionServiceImpl implements MemberConsumptionService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<MemberConsumptionResponseDto> findConsumptionByMember() {
+    public List<MemberConsumptionDto> findConsumptionByMember() {
         Long kakaoId = SecurityUtil.getCurrentMemberKakaoId();
         List<MemberConsumption> memberConsumptions
                 = memberConsumptionRepository.findMemberConsumptionByKakaoId(kakaoId);
 
         return memberConsumptions.stream()
-                .map(consumption -> MemberConsumptionResponseDto.builder()
+                .map(consumption -> MemberConsumptionDto.builder()
                         .companyType(consumption.getCompanyType())
                         .totalPrice(consumption.getTotalPrice())
                         .build()).toList();
@@ -58,17 +58,17 @@ public class MemberConsumptionServiceImpl implements MemberConsumptionService {
 
     @Override
     @Transactional(readOnly = true)
-    public MemberConsumptionResponseDto findConsumptionByMemberAndCompanyType(CompanyType companyType) {
+    public MemberConsumptionDto findConsumptionByMemberAndCompanyType(CompanyType companyType) {
         Long kakaoId = SecurityUtil.getCurrentMemberKakaoId();
         Optional<MemberConsumption> optionalConsumption = memberConsumptionRepository
                 .findConsumptionByKakaoIdAndCompanyType(kakaoId, companyType);
 
         return optionalConsumption
-                .map(consumption -> MemberConsumptionResponseDto.builder()
+                .map(consumption -> MemberConsumptionDto.builder()
                         .companyType(consumption.getCompanyType())
                         .totalPrice(consumption.getTotalPrice())
                         .build())
-                .orElse(MemberConsumptionResponseDto.builder()
+                .orElse(MemberConsumptionDto.builder()
                         .companyType(companyType)
                         .totalPrice(0L)
                         .build());

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/member/service/MemberService.java
@@ -17,4 +17,6 @@ public interface MemberService {
     AuthResponseDto getMemberAuth();
 
     KakaoIdStatusDto initMember(Long kakaoId);
+
+    String findMemberName();
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/member/service/MemberServiceImpl.java
@@ -58,4 +58,11 @@ public class MemberServiceImpl implements MemberService {
                 () -> new NotFoundMemberException(ErrorCode.MEMBER_NOT_FOUND));
     }
 
+
+    @Override
+    public String findMemberName() {
+        Long kakaoId = SecurityUtil.getCurrentMemberKakaoId();
+        return memberRepository.findMemberName(kakaoId).orElseThrow(
+                () -> new NotFoundMemberException(ErrorCode.MEMBER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/auth/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
                             .requestMatchers("/reviews/public/**").permitAll()
                             .requestMatchers("/company/public/**").permitAll()
                             .requestMatchers("/story/public/**").permitAll()
-                            .requestMatchers("/support/public").permitAll()
+                            .requestMatchers("/support/public/**").permitAll()
                             .requestMatchers("/auth/login/kakao",
                                     "/v3/api-docs/**",
                                     "/swagger-ui/**",

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/auth/springsecurity/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/auth/springsecurity/JwtAuthenticationFilter.java
@@ -42,7 +42,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/reviews/public/**",
             "/company/public/**",
             "/story/public/**",
-            "/support/public"
+            "/support/public/**"
     );
 
     @Override

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/member/GetMeberConsumptionDetailDocs.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/member/GetMeberConsumptionDetailDocs.java
@@ -1,6 +1,7 @@
 package com.example.seoulpublicdata2025backend.global.swagger.annotations.member;
 
-import com.example.seoulpublicdata2025backend.domain.member.dto.MemberConsumptionResponseDto;
+import com.example.seoulpublicdata2025backend.domain.member.dto.MemberConsumptionDetailResponseDto;
+import com.example.seoulpublicdata2025backend.domain.member.dto.MemberConsumptionDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -25,16 +26,19 @@ import java.lang.annotation.*;
         description = "기업 유형별 소비 내역 조회 성공",
         content = @Content(
                 mediaType = "application/json",
-                schema = @Schema(implementation = MemberConsumptionResponseDto.class),
+                schema = @Schema(implementation = MemberConsumptionDetailResponseDto.class),
                 examples = @ExampleObject(
                         name = "소비 내역 필터링 성공 예시",
                         value = """
-                                [
-                                  {
-                                    "companyType": "SOCIAL_SERVICE",
-                                    "totalPrice": 12000
+                                {
+                                  "name": "test-user",
+                                  "reviewCount": 5,
+                                  "consumption": {
+                                    "companyType": "사회서비스제공형",
+                                    "totalPrice": 13000
                                   }
-                                ]
+                                }
+                                
                                 """
                 )
         )

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/member/GetMemberConsumptionDocs.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/member/GetMemberConsumptionDocs.java
@@ -1,5 +1,6 @@
 package com.example.seoulpublicdata2025backend.global.swagger.annotations.member;
 
+import com.example.seoulpublicdata2025backend.domain.member.dto.MemberConsumptionDto;
 import com.example.seoulpublicdata2025backend.domain.member.dto.MemberConsumptionResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -23,16 +24,21 @@ import java.lang.annotation.*;
                 examples = @ExampleObject(
                         name = "소비 내역 예시",
                         value = """
-                                [
-                                  {
-                                    "companyType": "사회서비스제공형",
-                                    "totalPrice": 13000
-                                  },
-                                  {
-                                    "companyType": "일자리제공형",
-                                    "totalPrice": 8200
-                                  }
-                                ]
+                                {
+                                   "name": "test-user",
+                                   "reviewCount": 5,
+                                   "consumptions": [
+                                     {
+                                       "companyType": "사회서비스제공형",
+                                       "totalPrice": 13000
+                                     },
+                                     {
+                                       "companyType": "일자리제공형",
+                                       "totalPrice": 8200
+                                     }
+                                   ]
+                                 }
+                                
                                 """
                 )
         )

--- a/src/test/java/com/example/seoulpublicdata2025backend/domain/member/controller/MemberConsumptionControllerTest.java
+++ b/src/test/java/com/example/seoulpublicdata2025backend/domain/member/controller/MemberConsumptionControllerTest.java
@@ -1,0 +1,100 @@
+package com.example.seoulpublicdata2025backend.domain.member.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.seoulpublicdata2025backend.domain.company.entity.CompanyType;
+import com.example.seoulpublicdata2025backend.domain.member.dto.MemberConsumptionDto;
+import com.example.seoulpublicdata2025backend.domain.member.service.MemberConsumptionService;
+import com.example.seoulpublicdata2025backend.domain.member.service.MemberService;
+import com.example.seoulpublicdata2025backend.domain.review.service.ReviewService;
+import com.example.seoulpublicdata2025backend.global.exception.GlobalExceptionHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class MemberConsumptionControllerTest {
+
+    @Mock
+    MemberService memberService;
+
+    @Mock
+    ReviewService reviewService;
+
+    @Mock
+    MemberConsumptionService memberConsumptionService;
+
+    @InjectMocks
+    MemberConsumptionController memberConsumptionController;
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        mockMvc = MockMvcBuilders.standaloneSetup(memberConsumptionController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+
+    @Test
+    @DisplayName("MemberConsumption 조회 성공")
+    void getMemberConsumption_shouldReturnList() throws Exception {
+        List<MemberConsumptionDto> mockList = List.of(
+                MemberConsumptionDto.builder()
+                        .companyType(CompanyType.MIXED)
+                        .totalPrice(10000L)
+                        .build()
+        );
+
+        when(memberConsumptionService.findConsumptionByMember()).thenReturn(mockList);
+        when(memberService.findMemberName()).thenReturn("test-user");
+        when(reviewService.getCountMemberReview()).thenReturn(5L);
+
+        mockMvc.perform(get("/member/consumption"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("test-user"))
+                .andExpect(jsonPath("$.reviewCount").value(5))
+                .andExpect(jsonPath("$.consumptions[0].companyType").value("MIXED"))
+                .andExpect(jsonPath("$.consumptions[0].totalPrice").value(10000));
+    }
+
+    @Test
+    @DisplayName("카테고리에 대한 MemberConsumption 조회 성공")
+    void getMemberConsumptionDetail_shouldReturnDto() throws Exception {
+        MemberConsumptionDto dto = MemberConsumptionDto.builder()
+                .companyType(CompanyType.MIXED)
+                .totalPrice(5000L)
+                .build();
+
+        when(memberConsumptionService.findConsumptionByMemberAndCompanyType(CompanyType.MIXED)).thenReturn(dto);
+        when(memberService.findMemberName()).thenReturn("test-user");
+        when(reviewService.getCountMemberReview()).thenReturn(5L);
+
+        mockMvc.perform(get("/member/consumption/detail")
+                        .param("companyType", "MIXED"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("test-user"))
+                .andExpect(jsonPath("$.reviewCount").value(5))
+                .andExpect(jsonPath("$.consumption.totalPrice").value(5000))
+                .andExpect(jsonPath("$.consumption.companyType").value("MIXED"));
+    }
+
+}

--- a/src/test/java/com/example/seoulpublicdata2025backend/domain/member/controller/MemberControllerTests.java
+++ b/src/test/java/com/example/seoulpublicdata2025backend/domain/member/controller/MemberControllerTests.java
@@ -14,7 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.example.seoulpublicdata2025backend.domain.company.entity.CompanyType;
 import com.example.seoulpublicdata2025backend.domain.member.dto.AuthResponseDto;
-import com.example.seoulpublicdata2025backend.domain.member.dto.MemberConsumptionResponseDto;
+import com.example.seoulpublicdata2025backend.domain.member.dto.MemberConsumptionDto;
 import com.example.seoulpublicdata2025backend.domain.member.dto.SignupRequestDto;
 import com.example.seoulpublicdata2025backend.domain.member.dto.SignupResponseDto;
 import com.example.seoulpublicdata2025backend.domain.member.service.MemberConsumptionService;
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -124,41 +123,6 @@ class MemberControllerTests {
                 .andExpect(jsonPath("$.code").value("2000"))
                 .andExpect(jsonPath("$.errors").isArray())
                 .andExpect(jsonPath("$.errors[0].field").value("name"));
-    }
-
-    @Test
-    @DisplayName("MemberConsumption 조회 성공")
-    void getMemberConsumption_shouldReturnList() throws Exception {
-        List<MemberConsumptionResponseDto> mockList = List.of(
-                MemberConsumptionResponseDto.builder()
-                        .companyType(CompanyType.MIXED)
-                        .totalPrice(10000L)
-                        .build()
-        );
-
-        given(memberConsumptionService.findConsumptionByMember()).willReturn(mockList);
-
-        mockMvc.perform(get("/member/consumption"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].companyType").value("MIXED"))
-                .andExpect(jsonPath("$[0].totalPrice").value(10000));
-    }
-
-    @Test
-    @DisplayName("카테고리에 대한 MemberConsumption 조회 성공")
-    void getMemberConsumptionDetail_shouldReturnDto() throws Exception {
-        MemberConsumptionResponseDto dto = MemberConsumptionResponseDto.builder()
-                .companyType(CompanyType.MIXED)
-                .totalPrice(5000L)
-                .build();
-
-        given(memberConsumptionService.findConsumptionByMemberAndCompanyType(CompanyType.MIXED)).willReturn(dto);
-
-        mockMvc.perform(get("/member/consumption/detail")
-                        .param("companyType", "MIXED"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.companyType").value("MIXED"))
-                .andExpect(jsonPath("$.totalPrice").value(5000));
     }
 
     @Test

--- a/src/test/java/com/example/seoulpublicdata2025backend/domain/member/service/MemberConsumptionServiceImplTest.java
+++ b/src/test/java/com/example/seoulpublicdata2025backend/domain/member/service/MemberConsumptionServiceImplTest.java
@@ -10,7 +10,7 @@ import com.example.seoulpublicdata2025backend.domain.company.entity.CompanyType;
 import com.example.seoulpublicdata2025backend.domain.company.entity.Location;
 import com.example.seoulpublicdata2025backend.domain.member.dao.MemberConsumptionRepository;
 import com.example.seoulpublicdata2025backend.domain.member.dao.MemberRepository;
-import com.example.seoulpublicdata2025backend.domain.member.dto.MemberConsumptionResponseDto;
+import com.example.seoulpublicdata2025backend.domain.member.dto.MemberConsumptionDto;
 import com.example.seoulpublicdata2025backend.domain.member.entity.Member;
 import com.example.seoulpublicdata2025backend.domain.member.entity.MemberConsumption;
 import com.example.seoulpublicdata2025backend.global.exception.customException.NotFoundMemberException;
@@ -114,7 +114,7 @@ class MemberConsumptionServiceImplTest {
                 .thenReturn(List.of(consumption));
 
         // When
-        List<MemberConsumptionResponseDto> result = service.findConsumptionByMember();
+        List<MemberConsumptionDto> result = service.findConsumptionByMember();
 
         // Then
         assertEquals(1, result.size());
@@ -130,7 +130,7 @@ class MemberConsumptionServiceImplTest {
                 .thenReturn(List.of());
 
         // When
-        List<MemberConsumptionResponseDto> result = service.findConsumptionByMember();
+        List<MemberConsumptionDto> result = service.findConsumptionByMember();
 
         // Then
         assertThat(result.size()).isEqualTo(0);
@@ -150,7 +150,7 @@ class MemberConsumptionServiceImplTest {
                 .thenReturn(Optional.ofNullable(consumption));
 
         // When
-        MemberConsumptionResponseDto result = service.findConsumptionByMemberAndCompanyType(type);
+        MemberConsumptionDto result = service.findConsumptionByMemberAndCompanyType(type);
 
         // Then
         assertEquals(2000L, result.getTotalPrice());
@@ -165,7 +165,7 @@ class MemberConsumptionServiceImplTest {
                 CompanyType.JOB_PROVISION)
         ).thenReturn(Optional.empty());
 
-        MemberConsumptionResponseDto response =
+        MemberConsumptionDto response =
                 service.findConsumptionByMemberAndCompanyType(CompanyType.JOB_PROVISION);
 
         assertEquals(CompanyType.JOB_PROVISION, response.getCompanyType());


### PR DESCRIPTION
## 🌱 관련 이슈
- close #150 

## 📌 작업 내용 및 특이사항
- 소비 응답에 소비자 이름과 소비자가 작성한 리뷰 개수를 추가했습니다.
![image](https://github.com/user-attachments/assets/19ee6cce-2da5-4beb-b7c0-b77dd51511e6)
- 관련 swagger, test 을 알맞게 수정하였습니다.
- support 관련 security 설정을 추가하여 인증, 인가가 필요없게 변경하였습니다.
- 소비 관련을 컨트롤러 분리하여 MemberController(인증 위주 담당), MemberConsumptionController (소비 담당) 로 분리하였습니다.


## 📝 참고사항
-

## 📚 기타
-
