### PR TITLE
[Feat] 하나의 소비자 지원 상품을 조회하는 API 추가

### DIFF
--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/support/controller/SupportAnnouncementController.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/support/controller/SupportAnnouncementController.java
@@ -1,11 +1,13 @@
 package com.example.seoulpublicdata2025backend.domain.support.controller;
 
+import com.example.seoulpublicdata2025backend.domain.support.dto.ConsumerSupportProductResponseDetailDto;
 import com.example.seoulpublicdata2025backend.domain.support.dto.ConsumerSupportProductResponseDto;
 import com.example.seoulpublicdata2025backend.domain.support.dto.SupportAnnouncementDetailDto;
 import com.example.seoulpublicdata2025backend.domain.support.dto.SupportAnnouncementPreviewDto;
 import com.example.seoulpublicdata2025backend.domain.support.service.ConsumerSupportProductService;
 import com.example.seoulpublicdata2025backend.domain.support.service.SupportAnnouncementService;
 import com.example.seoulpublicdata2025backend.global.swagger.annotations.support.GetConsumerSupportProductsDocs;
+import com.example.seoulpublicdata2025backend.global.swagger.annotations.support.GetMemberSupportProductDetailDocs;
 import com.example.seoulpublicdata2025backend.global.swagger.annotations.support.SupportDetailDocs;
 import com.example.seoulpublicdata2025backend.global.swagger.annotations.support.SupportPreviewDocs;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +44,14 @@ public class SupportAnnouncementController {
     @GetConsumerSupportProductsDocs
     public ResponseEntity<List<ConsumerSupportProductResponseDto>> getMemberSupportProducts() {
         List<ConsumerSupportProductResponseDto> response = consumerSupportProductService.getMemberSupportProducts();
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/public/consumer/detail/{productId}")
+    @GetMemberSupportProductDetailDocs
+    public ResponseEntity<ConsumerSupportProductResponseDetailDto> getMemberSupportProductDetail(@PathVariable Integer productId) {
+        ConsumerSupportProductResponseDetailDto response =
+                consumerSupportProductService.getMemberSupportProductDetail(productId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/support/dto/ConsumerSupportProductResponseDetailDto.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/support/dto/ConsumerSupportProductResponseDetailDto.java
@@ -5,11 +5,11 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class ConsumerSupportProductResponseDto {
-    private Integer id;
+public class ConsumerSupportProductResponseDetailDto {
     private String bankName;
     private String productName;
     private String productType;
     private String benefit;
+    private String productLink;
     private String productDescription;
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/support/service/ConsumerSupportProductService.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/support/service/ConsumerSupportProductService.java
@@ -1,9 +1,11 @@
 package com.example.seoulpublicdata2025backend.domain.support.service;
 
+import com.example.seoulpublicdata2025backend.domain.support.dto.ConsumerSupportProductResponseDetailDto;
 import com.example.seoulpublicdata2025backend.domain.support.dto.ConsumerSupportProductResponseDto;
 
 import java.util.List;
 
 public interface ConsumerSupportProductService {
     List<ConsumerSupportProductResponseDto> getMemberSupportProducts();
+    ConsumerSupportProductResponseDetailDto getMemberSupportProductDetail(Integer productId);
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/support/service/ConsumerSupportProductServiceImpl.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/support/service/ConsumerSupportProductServiceImpl.java
@@ -1,8 +1,12 @@
 package com.example.seoulpublicdata2025backend.domain.support.service;
 
 import com.example.seoulpublicdata2025backend.domain.support.dao.ConsumerSupportProductRepository;
+import com.example.seoulpublicdata2025backend.domain.support.dto.ConsumerSupportProductResponseDetailDto;
 import com.example.seoulpublicdata2025backend.domain.support.dto.ConsumerSupportProductResponseDto;
 import com.example.seoulpublicdata2025backend.domain.support.entity.ConsumerSupportProduct;
+import com.example.seoulpublicdata2025backend.global.exception.customException.NotFoundSupportException;
+import com.example.seoulpublicdata2025backend.global.exception.errorCode.ErrorCode;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +25,7 @@ public class ConsumerSupportProductServiceImpl implements ConsumerSupportProduct
         List<ConsumerSupportProduct> consumerSupportProducts = consumerSupportProductRepository.findAll();
         return consumerSupportProducts.stream()
                 .map(support -> ConsumerSupportProductResponseDto.builder()
+                        .id(support.getId())
                         .bankName(support.getBankName())
                         .productName(support.getProductName())
                         .productDescription(support.getProductDescription())
@@ -28,5 +33,19 @@ public class ConsumerSupportProductServiceImpl implements ConsumerSupportProduct
                         .benefit(support.getBenefit())
                         .build()
                 ).toList();
+    }
+
+    @Override
+    public ConsumerSupportProductResponseDetailDto getMemberSupportProductDetail(Integer productId) {
+        ConsumerSupportProduct support = consumerSupportProductRepository.findById(Long.valueOf(productId))
+                .orElseThrow(() -> new NotFoundSupportException(ErrorCode.CONSUMER_SUPPORT_NOT_FOUND));
+        return ConsumerSupportProductResponseDetailDto.builder()
+                .bankName(support.getBankName())
+                .productName(support.getProductName())
+                .productDescription(support.getProductDescription())
+                .productType(support.getProductType())
+                .benefit(support.getBenefit())
+                .productLink(support.getProductLink())
+                .build();
     }
 }

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/exception/customException/NotFoundSupportException.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/exception/customException/NotFoundSupportException.java
@@ -1,0 +1,9 @@
+package com.example.seoulpublicdata2025backend.global.exception.customException;
+
+import com.example.seoulpublicdata2025backend.global.exception.errorCode.ErrorCode;
+
+public class NotFoundSupportException extends CustomException{
+    public NotFoundSupportException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/exception/errorCode/ErrorCode.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/exception/errorCode/ErrorCode.java
@@ -52,8 +52,9 @@ public enum ErrorCode {
     NAVER_OCR_INTERNAL_SERVER_ERROR("7001", "NAVER OCR 서버 오류가 발생했습니다. (500 Internal Server Error)",
             HttpStatus.INTERNAL_SERVER_ERROR),
 
-    // 8000번대: 지원 공고 관련
+    // 8000번대: 지원 관련
     SUPPORT_ANNOUNCEMENT_NOT_FOUND("8000", "해당 지원 공고가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    CONSUMER_SUPPORT_NOT_FOUND("8001", "해당 소비자 지원 상품이 존재하지 않습니다", HttpStatus.NOT_FOUND),
     ;
 
     private final String code;

--- a/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/support/GetMemberSupportProductDetailDocs.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/global/swagger/annotations/support/GetMemberSupportProductDetailDocs.java
@@ -1,0 +1,26 @@
+package com.example.seoulpublicdata2025backend.global.swagger.annotations.support;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "소비자 지원 상품 조회",
+        description = "해당 id를 가진 소비자 지원 상품을 조회합니다.",
+        parameters = {
+                @Parameter(name = "productId", description = "소비자 지원 상품 ID", required = true)
+        },
+        responses = {
+                @ApiResponse(responseCode = "200", description = "소비자 지원 상품 조회 성공"),
+        }
+)
+public @interface GetMemberSupportProductDetailDocs {
+}

--- a/src/test/java/com/example/seoulpublicdata2025backend/domain/support/service/ConsumerSupportProductServiceImplTest.java
+++ b/src/test/java/com/example/seoulpublicdata2025backend/domain/support/service/ConsumerSupportProductServiceImplTest.java
@@ -2,12 +2,16 @@ package com.example.seoulpublicdata2025backend.domain.support.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.example.seoulpublicdata2025backend.domain.support.dao.ConsumerSupportProductRepository;
+import com.example.seoulpublicdata2025backend.domain.support.dto.ConsumerSupportProductResponseDetailDto;
 import com.example.seoulpublicdata2025backend.domain.support.dto.ConsumerSupportProductResponseDto;
 import com.example.seoulpublicdata2025backend.domain.support.entity.ConsumerSupportProduct;
 import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -24,7 +28,8 @@ class ConsumerSupportProductServiceImplTest {
     ConsumerSupportProductServiceImpl consumerSupportProductService;
 
     @Test
-    void getMemberSupportProducts_정상조회() {
+    @DisplayName("소비자 지원 상품 전체 조회 성공")
+    void getMemberSupportProducts_success() {
         // given
         List<ConsumerSupportProduct> products = List.of(
                 ConsumerSupportProduct.builder()
@@ -52,5 +57,30 @@ class ConsumerSupportProductServiceImplTest {
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getBankName()).isEqualTo("카카오뱅크");
         assertThat(result.get(1).getProductName()).isEqualTo("사회적 기업 대출");
+    }
+
+    @Test
+    @DisplayName("하나의 소비자 지원 상품 조회 성공")
+    void get() throws Exception {
+        ConsumerSupportProduct supportProduct = ConsumerSupportProduct.builder()
+                .bankName("신한은행")
+                .productName("사회적 기업 대출")
+                .productDescription("사회적 기업을 위한 저금리 대출 상품")
+                .productType("대출")
+                .benefit("이자 지원")
+                .productLink("www.link.com")
+                .build();
+
+        when(consumerSupportProductRepository.findById(-1L)).thenReturn(Optional.of(supportProduct));
+
+        ConsumerSupportProductResponseDetailDto productDetail
+                = consumerSupportProductService.getMemberSupportProductDetail(-1);
+
+        assertThat(productDetail.getBankName()).isEqualTo("신한은행");
+        assertThat(productDetail.getProductName()).isEqualTo("사회적 기업 대출");
+        assertThat(productDetail.getProductDescription()).isEqualTo("사회적 기업을 위한 저금리 대출 상품");
+        assertThat(productDetail.getProductType()).isEqualTo("대출");
+        assertThat(productDetail.getBenefit()).isEqualTo("이자 지원");
+        assertThat(productDetail.getProductLink()).isEqualTo("www.link.com");
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #166 

## 📌 작업 내용 및 특이사항
- 하나의 소비자 지원 상품을 조회하는 API를 추가합니다.
- id를 파라미터로 받아서 응답을 내립니다.
```java
@GetMapping("/public/consumer/detail/{productId}")
    @GetMemberSupportProductDetailDocs
    public ResponseEntity<ConsumerSupportProductResponseDetailDto> getMemberSupportProductDetail(@PathVariable Integer productId) {
        ConsumerSupportProductResponseDetailDto response =
                consumerSupportProductService.getMemberSupportProductDetail(productId);
        return ResponseEntity.ok(response);
    }
```

## 📝 참고사항
-

## 📚 기타
-
