### PR TITLE
[Feat] CompanyCategory 값 반환하게 수정

### DIFF
--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/naverReceipt/dto/ReceiptInfoResponseDto.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/naverReceipt/dto/ReceiptInfoResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.seoulpublicdata2025backend.domain.naverReceipt.dto;
 
+import com.example.seoulpublicdata2025backend.domain.company.entity.CompanyCategory;
 import com.example.seoulpublicdata2025backend.domain.company.entity.Location;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,14 +16,14 @@ public class ReceiptInfoResponseDto {
     private final String companyCategory;
     private final Location location;
 
-    public static ReceiptInfoResponseDto of(ReceiptInfoDto dto, Location location) {
+    public static ReceiptInfoResponseDto of(ReceiptInfoDto dto, CompanyCategory companyCategory, Location location) {
         return new ReceiptInfoResponseDto(
                 dto.getStoreName(),
                 dto.getStoreAddress(),
                 dto.getStoreTel(),
                 dto.getOrderDateTime(),
                 dto.getConfirmNumber(),
-                dto.getCompanyCategory(),
+                companyCategory.getKoreanName(),
                 location
         );
     }

--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/naverReceipt/service/NaverReceiptServiceImpl.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/naverReceipt/service/NaverReceiptServiceImpl.java
@@ -42,7 +42,7 @@ public class NaverReceiptServiceImpl implements NaverReceiptService {
 
         memberConsumptionService.saveConsumption(companyDto, extractTotalPrice(ocrResponseDto));
 
-        return ReceiptInfoResponseDto.of(receiptInfoDto, companyDto.getLocation());
+        return ReceiptInfoResponseDto.of(receiptInfoDto, companyDto.getCompanyCategory(), companyDto.getLocation());
     }
 
     private boolean isNotSameCompany(CompanyLocationTypeDto companyDto, ReceiptInfoDto receiptInfoDto) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #197

## 📌 작업 내용 및 특이사항
- 네이버 영수증 반환값에 CompanyCategory 이 없던 에러를 수정했습니다.
- 필드 값은 있었지만, 따로 넣어주지 못해 발생한 에러였습니다.
```java
@Getter
@AllArgsConstructor
public class ReceiptInfoResponseDto {
    private final String storeName;
    private final String storeAddress;
    private final String storeTel;
    private final String orderDateTime;
    private final String confirmNumber;
    private final String companyCategory;
    private final Location location;

    public static ReceiptInfoResponseDto of(ReceiptInfoDto dto, CompanyCategory companyCategory, Location location) {
        return new ReceiptInfoResponseDto(
                dto.getStoreName(),
                dto.getStoreAddress(),
                dto.getStoreTel(),
                dto.getOrderDateTime(),
                dto.getConfirmNumber(),
                companyCategory.getKoreanName(),
                location
        );
    }
}
```

## 📝 참고사항
-

## 📚 기타
-
