### PR TITLE
[Feat] 쿠키 지속 시간 24시간으로 연장

### DIFF
--- a/src/main/java/com/example/seoulpublicdata2025backend/domain/member/util/CookieFactory.java
+++ b/src/main/java/com/example/seoulpublicdata2025backend/domain/member/util/CookieFactory.java
@@ -12,7 +12,7 @@ public class CookieFactory {
                 .sameSite("None")
                 .secure(true)
                 .domain(".morak.site")
-                .maxAge(Duration.ofHours(2))
+                .maxAge(Duration.ofHours(24))
                 .build();
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,7 +12,7 @@ kakao.auth.redirect=http://localhost:8080/auth/login/kakao
 
 # JWT
 jwt.secret=${JWT_SECRET}
-jwt.expireDate.accessToken=7200000
+jwt.expireDate.accessToken=86400000
 jwt.expireDate.refreshToken=2592000000
 
 # AWS


### PR DESCRIPTION
## 🌱 관련 이슈
- close #216 

## 📌 작업 내용 및 특이사항
- 토큰, 쿠키 지속 시간을 24시간으로 연장합니다

## 📝 참고사항
-

## 📚 기타
-
